### PR TITLE
feat: config collection

### DIFF
--- a/splunk/packages/edit-table/src/EditTable.jsx
+++ b/splunk/packages/edit-table/src/EditTable.jsx
@@ -16,8 +16,6 @@ import { formatCSVData } from './utils/csv';
 import { downloadFile } from './utils/file';
 import { getTableMetaData } from './utils/table';
 
-const DEFAULT_COLLECTION_NAME = 'example_collection';
-
 const TableButtonActionGroup = styled.div`
     position: absolute;
     bottom: 0;
@@ -25,14 +23,9 @@ const TableButtonActionGroup = styled.div`
     display: flex;
 `;
 
-const EditTable = ({
-    id,
-    dataSources,
-    onRequestParamsChange,
-    width,
-    height,
-    collectionName = DEFAULT_COLLECTION_NAME,
-}) => {
+const EditTable = (props) => {
+    const { id, dataSources, onRequestParamsChange, width, height, options } = props;
+    const collectionName = options.collection;
     const { api } = useDashboardApi();
 
     const style = useMemo(

--- a/splunk/packages/kv-editor/src/main/webapp/pages/dashboard/DashboardExample.jsx
+++ b/splunk/packages/kv-editor/src/main/webapp/pages/dashboard/DashboardExample.jsx
@@ -8,17 +8,6 @@ import { EditTable, RefreshButton, DashboardApiProvider } from '@splunk/edit-tab
 
 import definition from './definition.json';
 
-function withCollectionName(Component) {
-    const newComponent = function WrappedComponent(props) {
-        const collectionName = definition.visualizations.viz_editTable.options.collection;
-        return <Component {...props} collectionName={collectionName} />;
-    };
-    newComponent.config = Component.config;
-    newComponent.propTypes = Component.propTypes;
-    newComponent.defaultProps = Component.defaultProps;
-    return newComponent;
-}
-
 const themeToVariant = {
     enterprise: { colorScheme: 'light', family: 'enterprise' },
     enterpriseDark: { colorScheme: 'dark', family: 'enterprise' },
@@ -30,7 +19,7 @@ const customPreset = {
     ...EnterpriseViewOnlyPreset,
     visualizations: {
         ...EnterpriseViewOnlyPreset.visualizations,
-        'splunk.EditTable': withCollectionName(EditTable),
+        'splunk.EditTable': EditTable,
     },
 };
 


### PR DESCRIPTION
@marcusschiesser **withCollectionName** is still needed because we cannot get the definition.json in the EditorTable component. So I create **withCollectionName** to pass that prop to the component